### PR TITLE
Add browser-based flasher

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ A simple, low-cost touch-controlled Stream Deck–style macro pad built with Cir
 1. Copy `code.py` (the main script) to the root of your CIRCUITPY drive.
 2. Copy all required library folders from the Adafruit CircuitPython Bundle (displayio, touchscreen, HID) into `lib/` on the CIRCUITPY drive.
 
+## Web Flasher
+
+You can flash the CYD board directly from your browser using the files in
+`web-flasher/`. Because WebUSB and the File System Access API both require a
+secure context, you must open `index.html` from an HTTPS origin or `localhost`.
+
+1. Start a simple server in this repository (for example
+   `python -m http.server`).
+2. Navigate to `https://localhost:8000/web-flasher/` (adjust the port if
+   needed).
+3. Click **Connect** and choose the board's serial port.
+4. Click **Flash Firmware** to upload the provided CircuitPython firmware
+   (`firmware.uf2` or `firmware.bin`).
+5. Once the board resets and the `CIRCUITPY` drive appears, click **Copy
+   Libraries** and select that drive. `main.py` and library folders will be
+   copied automatically.
+
 ## Usage
 
 1. Plug the board into your computer via USB.

--- a/web-flasher/flash.js
+++ b/web-flasher/flash.js
@@ -1,0 +1,81 @@
+const connectBtn = document.getElementById('connect');
+const flashBtn = document.getElementById('flash');
+const copyBtn = document.getElementById('copy');
+const logEl = document.getElementById('log');
+
+let esptool;
+
+function log(msg) {
+  logEl.textContent += msg + '\n';
+}
+
+connectBtn.addEventListener('click', async () => {
+  try {
+    esptool = new ESPLoader();
+    await esptool.connect();
+    await esptool.flush();
+    log('Connected to serial port');
+    flashBtn.disabled = false;
+  } catch (err) {
+    log('Connection failed: ' + err);
+  }
+});
+
+flashBtn.addEventListener('click', async () => {
+  flashBtn.disabled = true;
+  log('Fetching firmware...');
+  try {
+    // fetch firmware binary placed next to this file
+    const resp = await fetch('firmware.uf2');
+    const fwData = new Uint8Array(await resp.arrayBuffer());
+    await esptool.writeFlash([[0x0, fwData]]);
+    log('Flashing complete, resetting...');
+    await esptool.hardReset();
+    await esptool.disconnect();
+    log('Waiting for CIRCUITPY drive to mount...');
+    // Give user time to select the drive
+    setTimeout(() => copyBtn.disabled = false, 4000);
+  } catch (err) {
+    log('Flash failed: ' + err);
+  }
+});
+
+copyBtn.addEventListener('click', async () => {
+  copyBtn.disabled = true;
+  try {
+    const rootDir = await window.showDirectoryPicker({ id: 'circuitpy' });
+    log('Copying main.py');
+    const mainResp = await fetch('../main.py');
+    const fileHandle = await rootDir.getFileHandle('main.py', { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(await mainResp.arrayBuffer());
+    await writable.close();
+
+    log('Ensuring lib folder exists');
+    const libDir = await rootDir.getDirectoryHandle('lib', { create: true });
+
+    const libs = ['adafruit_display_shapes', 'adafruit_display_text', 'adafruit_touchscreen', 'adafruit_hid'];
+    for (const lib of libs) {
+      try {
+        const resp = await fetch(`libs/${lib}.zip`);
+        if (!resp.ok) continue;
+        const data = await resp.arrayBuffer();
+        const zip = await JSZip.loadAsync(data);
+        const libFolder = await libDir.getDirectoryHandle(lib, { create: true });
+        for (const [name, file] of Object.entries(zip.files)) {
+          if (file.dir) continue;
+          const fHandle = await libFolder.getFileHandle(name, { create: true });
+          const wr = await fHandle.createWritable();
+          await wr.write(await file.async('arraybuffer'));
+          await wr.close();
+        }
+        log(`Copied ${lib}`);
+      } catch (e) {
+        log(`Skipping ${lib}: ${e}`);
+      }
+    }
+    log('Copy complete!');
+  } catch (err) {
+    log('Copy failed: ' + err);
+  }
+});

--- a/web-flasher/index.html
+++ b/web-flasher/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CYD Web Flasher</title>
+  <script src="https://unpkg.com/@esphome/esptool-web@latest/dist/web/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+</head>
+<body>
+  <h1>CYD Stream Deck Web Flasher</h1>
+  <button id="connect">Connect</button>
+  <button id="flash" disabled>Flash Firmware</button>
+  <button id="copy" disabled>Copy Libraries</button>
+
+  <pre id="log"></pre>
+
+  <script src="flash.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple web flasher using esptool-web
- include script to flash firmware and copy libraries
- document how to use the web flasher

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6849e4a0913083208fbb3f0a2f21a607